### PR TITLE
Arm64ec build hardening

### DIFF
--- a/scripts/arm64ec-common.sh
+++ b/scripts/arm64ec-common.sh
@@ -1,13 +1,15 @@
 ARM64EC_CPU_FLAGS=("-march=armv8.2-a" "-mtune=cortex-x3")
-ARM64EC_MESON_FLAGS=("${ARM64EC_CPU_FLAGS[@]}" "-O2" "-fwrapv" "-fno-strict-aliasing")
+# Correctness guards.
+ARM64EC_SAFETY_FLAGS=("-fno-strict-aliasing" "-fwrapv")
+ARM64EC_MESON_FLAGS=("${ARM64EC_CPU_FLAGS[@]}" "-O2" "${ARM64EC_SAFETY_FLAGS[@]}")
 
 arm64ec_join_flags() {
   local IFS=" "
   printf '%s' "$*"
 }
 
-arm64ec_cpu_flags() {
-  arm64ec_join_flags "${ARM64EC_CPU_FLAGS[@]}"
+arm64ec_cmake_flags() {
+  arm64ec_join_flags "${ARM64EC_CPU_FLAGS[@]}" "${ARM64EC_SAFETY_FLAGS[@]}"
 }
 
 arm64ec_meson_flags() {

--- a/scripts/build-targets.sh
+++ b/scripts/build-targets.sh
@@ -84,7 +84,7 @@ normalize_github_version_ref() {
       fi
       ;;
     fexcore)
-      # FEX tags look like FEX-2605; accept bare "2605" too.
+      # Accept bare 2605 too.
       if [[ "$raw" =~ ^[0-9] ]]; then
         printf 'FEX-%s\n' "$raw"
       else

--- a/scripts/local-build.sh
+++ b/scripts/local-build.sh
@@ -89,6 +89,10 @@ case "$kind" in
     ;;
 esac
 
+# FEX uses the validated bylaws arm64ec toolchain, NOT mainline.
+FEX_LLVM_MINGW_REPO="bylaws/llvm-mingw"
+FEX_LLVM_MINGW_TAG="20250920"
+
 maybe_relocate_to_native() {
   [[ "${WCP_NATIVE_ACTIVE:-}" == 1 ]] && return 0
   [[ "${WCP_NO_NATIVE:-}" == 1 ]] && return 0
@@ -112,7 +116,11 @@ maybe_relocate_to_native() {
 
   if ! $do_setup && [[ ! -x "$work/.venv/bin/meson" ]]; then
     echo "::notice::Initializing native toolchain/venv in $work (one-time)..."
-    ( cd "$work" && bash scripts/setup-local-llvm-meson.sh )
+    if [[ "$kind" == "fexcore" ]]; then
+      ( cd "$work" && LLVM_MINGW_REPO="$FEX_LLVM_MINGW_REPO" LLVM_MINGW_TAG="$FEX_LLVM_MINGW_TAG" bash scripts/setup-local-llvm-meson.sh )
+    else
+      ( cd "$work" && bash scripts/setup-local-llvm-meson.sh )
+    fi
   fi
 
   local child_args=(--kind "$kind")
@@ -135,15 +143,26 @@ maybe_relocate_to_native
 
 if $do_setup; then
   bash "$ROOT/scripts/install-deps-ubuntu.sh"
-  bash "$ROOT/scripts/setup-local-llvm-meson.sh"
+  if [[ "$kind" == "fexcore" ]]; then
+    LLVM_MINGW_REPO="$FEX_LLVM_MINGW_REPO" LLVM_MINGW_TAG="$FEX_LLVM_MINGW_TAG" \
+      bash "$ROOT/scripts/setup-local-llvm-meson.sh"
+  else
+    bash "$ROOT/scripts/setup-local-llvm-meson.sh"
+  fi
 fi
 
 if [[ -d "$ROOT/.venv/bin" ]]; then
   export PATH="$ROOT/.venv/bin:$PATH"
 fi
 
+fex_toolchain_dir="$ROOT/.toolchains/llvm-mingw-${FEX_LLVM_MINGW_TAG}"
+
 if [[ -n "${TOOLCHAIN_DIR:-}" && -d "$TOOLCHAIN_DIR/bin" ]]; then
   export PATH="$TOOLCHAIN_DIR/bin:$PATH"
+elif [[ "$kind" == "fexcore" && -d "$fex_toolchain_dir/bin" ]]; then
+  # FEX pins the bylaws toolchain.
+  export TOOLCHAIN_DIR="$fex_toolchain_dir"
+  export PATH="$fex_toolchain_dir/bin:$PATH"
 elif [[ -d "$ROOT/.toolchains" ]]; then
   latest_toolchain="$(find "$ROOT/.toolchains" -maxdepth 1 -type d -name 'llvm-mingw-*' | sort -V | tail -n1 || true)"
   if [[ -n "$latest_toolchain" && -d "$latest_toolchain/bin" ]]; then
@@ -153,6 +172,10 @@ elif [[ -d "$ROOT/.toolchains" ]]; then
 elif [[ -d /opt/llvm-mingw/bin ]]; then
   export TOOLCHAIN_DIR="/opt/llvm-mingw"
   export PATH="/opt/llvm-mingw/bin:$PATH"
+fi
+
+if [[ "$kind" == "fexcore" && "${TOOLCHAIN_DIR:-}" != "$fex_toolchain_dir" ]]; then
+  echo "::warning::FEX should build with ${FEX_LLVM_MINGW_REPO}@${FEX_LLVM_MINGW_TAG}, but active toolchain is '${TOOLCHAIN_DIR:-<none>}'. Run: scripts/local-build.sh --setup --kind fexcore" >&2
 fi
 
 need_cmd git
@@ -661,7 +684,7 @@ build_fexcore() {
   mkdir -p out
 
   local arch_flags
-  arch_flags="$(arm64ec_cpu_flags)"
+  arch_flags="$(arm64ec_cmake_flags)"
 
   fex_build_arch() {
     local triple="$1" dest="$2"

--- a/scripts/packing.sh
+++ b/scripts/packing.sh
@@ -46,6 +46,16 @@ source "$PROFILE_SH"
 : "${WCP_TYPE:?WCP_TYPE not set in profile}"
 : "${WCP_DESC:?WCP_DESC not set in profile}"
 
+wcp_should_strip() {
+  local f="$1"
+  [[ "$WCP_TYPE" == "FEXCore" ]] && return 1
+  if have_cmd llvm-readobj \
+     && llvm-readobj -h "$f" 2>/dev/null | grep -qiE 'Machine:.*ARM64EC'; then
+    return 1
+  fi
+  return 0
+}
+
 if [[ -n "${WCP_VERSION_CODE:-}" ]]; then
   FINAL_VER_CODE="$WCP_VERSION_CODE"
 else
@@ -134,10 +144,12 @@ if [[ -n "${WCP_SINGLE_BIN_SOURCE:-}" ]]; then
   chmod u+w "$WCP_DIR/$BIN_NAME" 2>/dev/null || true
 
   if [[ "$HAVE_LLVM_STRIP" -eq 1 ]]; then
-    # DLLs get the same aggressive strip as the graphics path; PE exports live
-    # in the export directory, not the symbol table, so --strip-all is safe.
     if [[ "${BIN_NAME,,}" == *.dll ]]; then
-      llvm-strip --strip-all "$WCP_DIR/$BIN_NAME" 2>/dev/null || true
+      if wcp_should_strip "$WCP_DIR/$BIN_NAME"; then
+        llvm-strip --strip-all "$WCP_DIR/$BIN_NAME" 2>/dev/null || true
+      else
+        echo "Preserving symbols for $BIN_NAME (FEX/ARM64EC: strip disabled)."
+      fi
     else
       llvm-strip --strip-unneeded "$WCP_DIR/$BIN_NAME" 2>/dev/null || true
     fi
@@ -263,7 +275,13 @@ fi
 echo "Stripping symbols..."
 if [[ "$HAVE_LLVM_STRIP" -eq 1 ]]; then
   find "$WCP_DIR" -iname '*.dll' -print0 | xargs -0 -r chmod u+w || true
-  find "$WCP_DIR" -iname '*.dll' -print0 | xargs -0 -r llvm-strip --strip-all || true
+  while IFS= read -r -d '' dll; do
+    if wcp_should_strip "$dll"; then
+      llvm-strip --strip-all "$dll" 2>/dev/null || true
+    else
+      echo "Preserving symbols for ${dll##*/} (FEX/ARM64EC: strip disabled)."
+    fi
+  done < <(find "$WCP_DIR" -iname '*.dll' -print0)
 else
   echo "Skipping DLL strip (llvm-strip not available)."
 fi

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -1,0 +1,20 @@
+
+declare -A REL_NOTE=(
+  [general]="- General-purpose x64/x86 build"
+  [fexonly]="- For FEX only"
+  [common]="- Common: Uses Valve-style build flags. Compatibility may be reduced."
+  [prereg]="- pre-reg: Last version before the performance drop on Turnip driver."
+  [binsem]="- binsem: Avoids Turnip performance loss without env vars. May be unstable."
+  [dyasync]="- Dyasync can be disabled by \`DXVK_DISABLE_DYASYNC=1\`"
+)
+
+render_notes() {
+  local key
+  for key in "$@"; do
+    if [[ -n "${REL_NOTE[$key]+x}" ]]; then
+      printf '%s\n' "${REL_NOTE[$key]}"
+    else
+      echo "::warning::unknown release-note key: $key" >&2
+    fi
+  done
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,6 +12,13 @@ REF="${REF:-}"
 
 NOTES="${NOTES:-RELEASE_NOTES.md}"
 BODY="${BODY:-}"
+BODY_KEYS="${BODY_KEYS:-}"
+
+if [[ -z "$BODY" && -n "$BODY_KEYS" ]]; then
+  source "$(dirname "$0")/release-notes.sh"
+  IFS=' ' read -ra _note_keys <<<"$BODY_KEYS"
+  BODY="$(render_notes "${_note_keys[@]}")"
+fi
 
 : >"$NOTES"
 if [[ -n "$BODY" ]]; then


### PR DESCRIPTION
- FEX: added missing `-fno-strict-aliasing` and `-fwrapv`
- ARM64EC: never use `--strip-all` (DXVK and VKD3D are less affected, so the current assets will remain as they are.)
- Split toolchains: Bylaws / llvm-mingw 20250920 for fex
- DRY release notes
